### PR TITLE
Switch to structuredClone

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ const useReactive = <T extends object>(state: T): T => {
 
   const updateState = (path: Path, value: any) => {
     setVariable(prevState => {
-      const newState = JSON.parse(JSON.stringify(prevState)); // Create a deep copy
+      const newState = structuredClone(prevState); // Create a deep copy
       let current: any = newState;
       for (let i = 0; i < path.length - 1; i++) {
         current = current[path[i]];


### PR DESCRIPTION
By changing to [structuredClone ](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)one can support more [JavaScript types
](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types)